### PR TITLE
Feat/filter conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# Diretórios e arquivos específicos do Maven
+/target/
+/pom.xml.tag
+/pom.xml.releaseBackup
+/pom.xml.versionsBackup
+/logging.properties
+/release.properties
+dependency-reduced-pom.xml
+
+# Diretórios e arquivos específicos do Java
+*.class
+*.jar
+*.war
+*.ear
+
+# Arquivos de log
+*.log
+
+# Configurações de ambiente
+.env
+
+# Configurações específicas do VSCode
+.vscode/
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# Arquivos temporários e caches de sistema
+*.tmp
+*.bak
+*.swp
+*.DS_Store
+Thumbs.db
+
+# Arquivos de configuração do sistema operacional
+.DS_Store
+.idea/
+.project
+.classpath
+
+# Configurações de builds locais
+target/
+out/
+bin/
+
+# Cache do Maven
+.m2/repository/
+
+# Outras configurações de IDEs
+/.factorypath
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -1,21 +1,54 @@
-# BigQuery Test Configuration
+Aqui está o `README.md` com os passos detalhados para duplicar, renomear e publicar sua imagem Docker personalizada no Docker Hub:
 
-In order to test the BigQuery source, you need a service account key file.
+```markdown
+# Conector Customizado do BigQuery
 
-## Community Contributor
+Este guia fornece instruções para duplicar o conector BigQuery da Airbyte, personalizar e publicar sua própria imagem Docker.
 
-As a community contributor, you will need access to a GCP project and BigQuery to run tests.
+## Passo a Passo
 
-1. Go to the `Service Accounts` page on the GCP console
-1. Click on `+ Create Service Account" button
-1. Fill out a descriptive name/id/description
-1. Click the edit icon next to the service account you created on the `IAM` page
-1. Add the `BigQuery Data Editor` and `BigQuery User` role
-1. Go back to the `Service Accounts` page and use the actions modal to `Create Key`
-1. Download this key as a JSON file
-1. Move and rename this file to `secrets/credentials.json`
+### 1. Duplicar e Renomear a Pasta do Conector
 
-## Airbyte Employee
+Primeiro, faça uma cópia da pasta do conector `source-bigquery` para `source-custom-bigquery`:
 
-1. Access the `BigQuery Integration Test User` secret on Rippling under the `Engineering` folder
-1. Create a file with the contents at `secrets/credentials.json`
+```bash
+cp -r /airbyte/airbyte-integrations/connectors/source-bigquery /airbyte/airbyte-integrations/connectors/source-custom-bigquery
+```
+
+### 2. Gerar a Imagem Docker do Conector Customizado
+
+Após duplicar a pasta, gere a imagem Docker para o novo conector com o comando:
+
+```bash
+airbyte-ci connectors --name source-custom-bigquery build
+```
+
+### 3. Renomear a Imagem Docker para seu Docker Hub
+
+Renomeie a imagem criada para o repositório do Docker Hub, substituindo `<seu_dockerhub_usuario>` pelo seu nome de usuário no Docker Hub (neste caso, `diegocoliveira07`):
+
+```bash
+docker tag airbyte/source-custom-bigquery:dev diegocoliveira07/source-custom-bigquery:0.1.4
+```
+
+### 4. Login no Docker Hub
+
+Faça login no Docker Hub para autenticar sua conta:
+
+```bash
+docker login
+```
+
+### 5. Publicar a Imagem Docker no Docker Hub
+
+Após o login, publique a imagem no Docker Hub:
+
+```bash
+docker push diegocoliveira07/source-custom-bigquery:0.1.4
+```
+
+---
+
+Agora, a imagem `diegocoliveira07/source-custom-bigquery:0.1.4` estará disponível no Docker Hub e pronta para ser usada ou compartilhada!
+```
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ airbyte-ci connectors --name source-custom-bigquery build
 Renomeie a imagem criada para o repositório do Docker Hub, substituindo `<seu_dockerhub_usuario>` pelo seu nome de usuário no Docker Hub (neste caso, `diegocoliveira07`):
 
 ```bash
-docker tag airbyte/source-custom-bigquery:dev diegocoliveira07/source-custom-bigquery:0.1.4
+docker tag airbyte/source-custom-bigquery:dev diegocoliveira07/source-custom-bigquery:0.1.6
 ```
 
 ### 4. Login no Docker Hub
@@ -44,11 +44,11 @@ docker login
 Após o login, publique a imagem no Docker Hub:
 
 ```bash
-docker push diegocoliveira07/source-custom-bigquery:0.1.4
+docker push diegocoliveira07/source-custom-bigquery:0.1.6
 ```
 
 ---
 
-Agora, a imagem `diegocoliveira07/source-custom-bigquery:0.1.4` estará disponível no Docker Hub e pronta para ser usada ou compartilhada!
+Agora, a imagem `diegocoliveira07/source-custom-bigquery:0.1.6` estará disponível no Docker Hub e pronta para ser usada ou compartilhada!
 ```
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: bfd1ddf8-ae8a-4620-b1d7-55597d2ba08c
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.4
   dockerRepository: diegocoliveira07/source-custom-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/sources/bigquery
   githubIssueLabel: source-bigquery

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: bfd1ddf8-ae8a-4620-b1d7-55597d2ba08c
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.6
   dockerRepository: diegocoliveira07/source-custom-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/sources/bigquery
   githubIssueLabel: source-bigquery

--- a/src/main/java/io/airbyte/integrations/source/bigquery/BigQuerySource.java
+++ b/src/main/java/io/airbyte/integrations/source/bigquery/BigQuerySource.java
@@ -47,216 +47,203 @@ import org.slf4j.LoggerFactory;
 
 public class BigQuerySource extends AbstractDbSource<StandardSQLTypeName, BigQueryDatabase> implements Source {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BigQuerySource.class);
-  private static final String QUOTE = "`";
+    private static final Logger LOGGER = LoggerFactory.getLogger(BigQuerySource.class);
+    private static final String QUOTE = "`";
 
-  public static final String CONFIG_DATASET_ID = "dataset_id";
-  public static final String CONFIG_PROJECT_ID = "project_id";
-  public static final String CONFIG_CREDS = "credentials_json";
-  public static final String CONFIG_ADDITIONAL = "additional_config";
-  public static final String CONFIG_TABLENAME = "tablename";
-  public static final String CONFIG_FILTER_CONDITION = "filter_condition";
-  private JsonNode dbConfig;
-  private Map<String, String> tableFilterConditions = new HashMap<>();
-  private final BigQuerySourceOperations sourceOperations = new BigQuerySourceOperations();
+    public static final String CONFIG_DATASET_ID = "dataset_id";
+    public static final String CONFIG_PROJECT_ID = "project_id";
+    public static final String CONFIG_CREDS = "credentials_json";
+    public static final String CONFIG_ADDITIONAL = "additional_config";
+    public static final String CONFIG_TABLENAME = "tablename";
+    public static final String CONFIG_FILTER_CONDITION = "filter_condition";
+    private JsonNode dbConfig;
+    private Map<String, String> tableFilterConditions = new HashMap<>();
+    private final BigQuerySourceOperations sourceOperations = new BigQuerySourceOperations();
 
-  protected BigQuerySource() {
-    super(null);
-  }
-
-  @Override
-  public JsonNode toDatabaseConfig(final JsonNode config) {
-    final var conf = ImmutableMap.builder()
-        .put(CONFIG_PROJECT_ID, config.get(CONFIG_PROJECT_ID).asText())
-        .put(CONFIG_CREDS, config.get(CONFIG_CREDS).asText());
-    if (config.hasNonNull(CONFIG_DATASET_ID)) {
-      conf.put(CONFIG_DATASET_ID, config.get(CONFIG_DATASET_ID).asText());
+    protected BigQuerySource() {
+        super(null);
     }
-    return Jsons.jsonNode(conf.build());
-  }
 
-  @Override
-  protected BigQueryDatabase createDatabase(final JsonNode sourceConfig) {
-    dbConfig = Jsons.clone(sourceConfig);
-    setFilterConditions(sourceConfig);
-    final BigQueryDatabase database = new BigQueryDatabase(sourceConfig.get(CONFIG_PROJECT_ID).asText(),
-        sourceConfig.get(CONFIG_CREDS).asText());
-    database.setSourceConfig(sourceConfig);
-    database.setDatabaseConfig(toDatabaseConfig(sourceConfig));
-    return database;
-  }
-
-  @Override
-  public List<CheckedConsumer<BigQueryDatabase, Exception>> getCheckOperations(final JsonNode config) {
-    final List<CheckedConsumer<BigQueryDatabase, Exception>> checkList = new ArrayList<>();
-    checkList.add(database -> {
-      if (database.query("select 1").count() < 1)
-        throw new Exception("Unable to execute any query on the source!");
-      else
-        LOGGER.info("The source passed the basic query test!");
-    });
-
-    checkList.add(database -> {
-      if (isDatasetConfigured(database)) {
-        database.query(String.format("select 1 from %s where 1=0",
-            getFullyQualifiedTableNameWithQuoting(getConfigDatasetId(database), "INFORMATION_SCHEMA.TABLES",
-                getQuoteString())));
-        LOGGER.info("The source passed the Dataset query test!");
-      } else {
-        LOGGER.info("The Dataset query test is skipped due to not configured datasetId!");
-      }
-    });
-
-    return checkList;
-  }
-
-  @Override
-  protected JsonSchemaType getAirbyteType(final StandardSQLTypeName columnType) {
-    return switch (columnType) {
-      case StandardSQLTypeName.DATE -> JsonSchemaType.STRING_DATE;
-      case StandardSQLTypeName.DATETIME -> JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE;
-      case StandardSQLTypeName.TIMESTAMP -> JsonSchemaType.STRING_TIMESTAMP_WITH_TIMEZONE;
-      default -> sourceOperations.getAirbyteType(columnType);
-    };
-
-  }
-
-  @Override
-  public Set<String> getExcludedInternalNameSpaces() {
-    return Collections.emptySet();
-  }
-
-  @Override
-  protected List<TableInfo<CommonField<StandardSQLTypeName>>> discoverInternal(final BigQueryDatabase database)
-      throws Exception {
-    return discoverInternal(database, null);
-  }
-
-  @Override
-  protected List<TableInfo<CommonField<StandardSQLTypeName>>> discoverInternal(final BigQueryDatabase database,
-      final String schema) {
-    final String projectId = dbConfig.get(CONFIG_PROJECT_ID).asText();
-    final List<Table> tables = (isDatasetConfigured(database) ? database.getDatasetTables(getConfigDatasetId(database))
-        : database.getProjectTables(projectId));
-    final List<TableInfo<CommonField<StandardSQLTypeName>>> result = new ArrayList<>();
-    tables.stream().map(table -> TableInfo.<CommonField<StandardSQLTypeName>>builder()
-        .nameSpace(table.getTableId().getDataset())
-        .name(table.getTableId().getTable())
-        .fields(Objects.requireNonNull(table.getDefinition().getSchema()).getFields().stream()
-            .map(f -> {
-              final StandardSQLTypeName standardType;
-              if (f.getType().getStandardType() == StandardSQLTypeName.STRUCT && f.getMode() == Field.Mode.REPEATED) {
-                standardType = StandardSQLTypeName.ARRAY;
-              } else
-                standardType = f.getType().getStandardType();
-
-              return new CommonField<>(f.getName(), standardType);
-            })
-            .collect(Collectors.toList()))
-        .build())
-        .forEach(result::add);
-    return result;
-  }
-
-  @Override
-  protected Map<String, List<String>> discoverPrimaryKeys(final BigQueryDatabase database,
-      final List<TableInfo<CommonField<StandardSQLTypeName>>> tableInfos) {
-    return Collections.emptyMap();
-  }
-
-  @Override
-  protected String getQuoteString() {
-    return QUOTE;
-  }
-
-  @Override
-  public AutoCloseableIterator<JsonNode> queryTableIncremental(final BigQueryDatabase database,
-      final List<String> columnNames,
-      final String schemaName,
-      final String tableName,
-      final CursorInfo cursorInfo,
-      final StandardSQLTypeName cursorFieldType) {
-    return queryTableWithParams(database, String.format("SELECT %s FROM %s WHERE %s > ?",
-        RelationalDbQueryUtils.enquoteIdentifierList(columnNames, getQuoteString()),
-        getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString()),
-        cursorInfo.getCursorField()),
-        schemaName,
-        tableName,
-        sourceOperations.getQueryParameter(cursorFieldType, cursorInfo.getCursor()));
-  }
-
-  @Override
-  protected AutoCloseableIterator<JsonNode> queryTableFullRefresh(final BigQueryDatabase database,
-      final List<String> columnNames,
-      final String schemaName,
-      final String tableName,
-      final SyncMode syncMode,
-      final Optional<String> cursorField) {
-    LOGGER.info("Queueing query for table: {}", tableName);
-    String sqlQuery = String.format("SELECT %s FROM %s WHERE %s",
-        enquoteIdentifierList(columnNames, getQuoteString()),
-        getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString()),
-        getFilterConditions(tableName));
-
-    return queryTable(database, sqlQuery, schemaName, tableName);
-
-  }
-
-  @Override
-  public boolean isCursorType(final StandardSQLTypeName standardSQLTypeName) {
-    return true;
-  }
-
-  private AutoCloseableIterator<JsonNode> queryTableWithParams(final BigQueryDatabase database,
-      final String sqlQuery,
-      final String schemaName,
-      final String tableName,
-      final QueryParameterValue... params) {
-    final AirbyteStreamNameNamespacePair airbyteStream = AirbyteStreamUtils.convertFromNameAndNamespace(tableName,
-        schemaName);
-    return AutoCloseableIterators.lazyIterator(() -> {
-      try {
-        final Stream<JsonNode> stream = database.query(sqlQuery, params);
-        return AutoCloseableIterators.fromStream(stream, airbyteStream);
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    }, airbyteStream);
-  }
-
-  private void setFilterConditions(final JsonNode config) {
-    JsonNode additionalConfig = config.get(CONFIG_ADDITIONAL);
-    if (additionalConfig != null) {
-      for (JsonNode node : additionalConfig) {
-        String tablename = node.get(CONFIG_TABLENAME).asText();
-        String filterCondition = node.get(CONFIG_FILTER_CONDITION).asText();
-        tableFilterConditions.put(tablename, filterCondition);
-      }
+    @Override
+    public JsonNode toDatabaseConfig(final JsonNode config) {
+        final var conf = ImmutableMap.builder().put(CONFIG_PROJECT_ID, config.get(CONFIG_PROJECT_ID).asText())
+                .put(CONFIG_CREDS, config.get(CONFIG_CREDS).asText());
+        if (config.hasNonNull(CONFIG_DATASET_ID)) {
+            conf.put(CONFIG_DATASET_ID, config.get(CONFIG_DATASET_ID).asText());
+        }
+        return Jsons.jsonNode(conf.build());
     }
-  }
 
-  private String getFilterConditions(final String tableName) {
-    return tableFilterConditions.getOrDefault(tableName, "1=1");
-  }
+    @Override
+    protected BigQueryDatabase createDatabase(final JsonNode sourceConfig) {
+        dbConfig = Jsons.clone(sourceConfig);
+        setFilterConditions(sourceConfig);
+        final BigQueryDatabase database = new BigQueryDatabase(sourceConfig.get(CONFIG_PROJECT_ID).asText(),
+                sourceConfig.get(CONFIG_CREDS).asText());
+        database.setSourceConfig(sourceConfig);
+        database.setDatabaseConfig(toDatabaseConfig(sourceConfig));
+        return database;
+    }
 
-  private boolean isDatasetConfigured(final SqlDatabase database) {
-    final JsonNode config = database.getSourceConfig();
-    return config.hasNonNull(CONFIG_DATASET_ID) ? !config.get(CONFIG_DATASET_ID).asText().isEmpty() : false;
-  }
+    @Override
+    public List<CheckedConsumer<BigQueryDatabase, Exception>> getCheckOperations(final JsonNode config) {
+        final List<CheckedConsumer<BigQueryDatabase, Exception>> checkList = new ArrayList<>();
+        checkList.add(database -> {
+            if (database.query("select 1").count() < 1)
+                throw new Exception("Unable to execute any query on the source!");
+            else
+                LOGGER.info("The source passed the basic query test!");
+        });
 
-  private String getConfigDatasetId(final SqlDatabase database) {
-    return (isDatasetConfigured(database) ? database.getSourceConfig().get(CONFIG_DATASET_ID).asText() : "");
-  }
+        checkList.add(database -> {
+            if (isDatasetConfigured(database)) {
+                database.query(String.format("select 1 from %s where 1=0", getFullyQualifiedTableNameWithQuoting(
+                        getConfigDatasetId(database), "INFORMATION_SCHEMA.TABLES", getQuoteString())));
+                LOGGER.info("The source passed the Dataset query test!");
+            } else {
+                LOGGER.info("The Dataset query test is skipped due to not configured datasetId!");
+            }
+        });
 
-  public static void main(final String[] args) throws Exception {
-    final Source source = new BigQuerySource();
-    LOGGER.info("starting source: {}", BigQuerySource.class);
-    new IntegrationRunner(source).run(args);
-    LOGGER.info("completed source: {}", BigQuerySource.class);
-  }
+        return checkList;
+    }
 
-  @Override
-  public void close() throws Exception {
-  }
+    @Override
+    protected JsonSchemaType getAirbyteType(final StandardSQLTypeName columnType) {
+        return switch (columnType) {
+            case StandardSQLTypeName.DATE -> JsonSchemaType.STRING_DATE;
+            case StandardSQLTypeName.DATETIME -> JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE;
+            case StandardSQLTypeName.TIMESTAMP -> JsonSchemaType.STRING_TIMESTAMP_WITH_TIMEZONE;
+            default -> sourceOperations.getAirbyteType(columnType);
+        };
+
+    }
+
+    @Override
+    public Set<String> getExcludedInternalNameSpaces() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    protected List<TableInfo<CommonField<StandardSQLTypeName>>> discoverInternal(final BigQueryDatabase database)
+            throws Exception {
+        return discoverInternal(database, null);
+    }
+
+    @Override
+    protected List<TableInfo<CommonField<StandardSQLTypeName>>> discoverInternal(final BigQueryDatabase database,
+            final String schema) {
+        final String projectId = dbConfig.get(CONFIG_PROJECT_ID).asText();
+        final List<Table> tables =
+                (isDatasetConfigured(database) ? database.getDatasetTables(getConfigDatasetId(database))
+                        : database.getProjectTables(projectId));
+        final List<TableInfo<CommonField<StandardSQLTypeName>>> result = new ArrayList<>();
+        tables.stream().map(table -> TableInfo.<CommonField<StandardSQLTypeName>>builder()
+                .nameSpace(table.getTableId().getDataset()).name(table.getTableId().getTable())
+                .fields(Objects.requireNonNull(table.getDefinition().getSchema()).getFields().stream().map(f -> {
+                    final StandardSQLTypeName standardType;
+                    if (f.getType().getStandardType() == StandardSQLTypeName.STRUCT
+                            && f.getMode() == Field.Mode.REPEATED) {
+                        standardType = StandardSQLTypeName.ARRAY;
+                    } else
+                        standardType = f.getType().getStandardType();
+
+                    return new CommonField<>(f.getName(), standardType);
+                }).collect(Collectors.toList())).build()).forEach(result::add);
+        return result;
+    }
+
+    @Override
+    protected Map<String, List<String>> discoverPrimaryKeys(final BigQueryDatabase database,
+            final List<TableInfo<CommonField<StandardSQLTypeName>>> tableInfos) {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    protected String getQuoteString() {
+        return QUOTE;
+    }
+
+    @Override
+    public AutoCloseableIterator<JsonNode> queryTableIncremental(final BigQueryDatabase database,
+            final List<String> columnNames, final String schemaName, final String tableName,
+            final CursorInfo cursorInfo, final StandardSQLTypeName cursorFieldType) {
+        return queryTableWithParams(database,
+                String.format("SELECT %s FROM %s WHERE %s > ?",
+                        RelationalDbQueryUtils.enquoteIdentifierList(columnNames, getQuoteString()),
+                        getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString()),
+                        cursorInfo.getCursorField()),
+                schemaName, tableName, sourceOperations.getQueryParameter(cursorFieldType, cursorInfo.getCursor()));
+    }
+
+    @Override
+    protected AutoCloseableIterator<JsonNode> queryTableFullRefresh(final BigQueryDatabase database,
+            final List<String> columnNames, final String schemaName, final String tableName, final SyncMode syncMode,
+            final Optional<String> cursorField) {
+        LOGGER.info("Queueing query for table: {}", tableName);
+        String sqlQuery =
+                String.format("SELECT %s FROM %s WHERE %s", enquoteIdentifierList(columnNames, getQuoteString()),
+                        getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString()),
+                        getFilterConditions(tableName));
+
+        return queryTable(database, sqlQuery, schemaName, tableName);
+
+    }
+
+    @Override
+    public boolean isCursorType(final StandardSQLTypeName standardSQLTypeName) {
+        return true;
+    }
+
+    private AutoCloseableIterator<JsonNode> queryTableWithParams(final BigQueryDatabase database, final String sqlQuery,
+            final String schemaName, final String tableName, final QueryParameterValue... params) {
+        final AirbyteStreamNameNamespacePair airbyteStream =
+                AirbyteStreamUtils.convertFromNameAndNamespace(tableName, schemaName);
+        return AutoCloseableIterators.lazyIterator(() -> {
+            try {
+                final Stream<JsonNode> stream = database.query(sqlQuery, params);
+                return AutoCloseableIterators.fromStream(stream, airbyteStream);
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, airbyteStream);
+    }
+
+    private void setFilterConditions(final JsonNode config) {
+        JsonNode additionalConfig = config.path(CONFIG_ADDITIONAL);
+        if (!additionalConfig.isMissingNode()) {
+            additionalConfig.forEach(node -> {
+                JsonNode tablename = node.path(CONFIG_TABLENAME);
+                JsonNode filterCondition = node.path(CONFIG_FILTER_CONDITION);
+                if (!tablename.isMissingNode() && !filterCondition.isMissingNode()) {
+                    tableFilterConditions.put(tablename.asText(), filterCondition.asText());
+                }
+
+            });
+        }
+    }
+
+    private String getFilterConditions(final String tableName) {
+        return tableFilterConditions.getOrDefault(tableName, "1=1");
+    }
+
+    private boolean isDatasetConfigured(final SqlDatabase database) {
+        final JsonNode config = database.getSourceConfig();
+        return config.hasNonNull(CONFIG_DATASET_ID) ? !config.get(CONFIG_DATASET_ID).asText().isEmpty() : false;
+    }
+
+    private String getConfigDatasetId(final SqlDatabase database) {
+        return (isDatasetConfigured(database) ? database.getSourceConfig().get(CONFIG_DATASET_ID).asText() : "");
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Source source = new BigQuerySource();
+        LOGGER.info("starting source: {}", BigQuerySource.class);
+        new IntegrationRunner(source).run(args);
+        LOGGER.info("completed source: {}", BigQuerySource.class);
+    }
+
+    @Override
+    public void close() throws Exception {}
 
 }

--- a/src/main/java/io/airbyte/integrations/source/bigquery/BigQuerySource.java
+++ b/src/main/java/io/airbyte/integrations/source/bigquery/BigQuerySource.java
@@ -112,7 +112,13 @@ public class BigQuerySource extends AbstractDbSource<StandardSQLTypeName, BigQue
 
   @Override
   protected JsonSchemaType getAirbyteType(final StandardSQLTypeName columnType) {
-    return sourceOperations.getAirbyteType(columnType);
+    return switch (columnType) {
+      case StandardSQLTypeName.DATE -> JsonSchemaType.STRING_DATE;
+      case StandardSQLTypeName.DATETIME -> JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE;
+      case StandardSQLTypeName.TIMESTAMP -> JsonSchemaType.STRING_TIMESTAMP_WITH_TIMEZONE;
+      default -> sourceOperations.getAirbyteType(columnType);
+    };
+
   }
 
   @Override

--- a/src/main/resources/spec.json
+++ b/src/main/resources/spec.json
@@ -10,7 +10,7 @@
     "properties": {
       "project_id": {
         "type": "string",
-        "description": "[Desenvolvido por DIEGO OLIVEIRA] The GCP project ID for the project containing the target BigQuery dataset.",
+        "description": "The GCP project ID for the project containing the target BigQuery dataset.",
         "title": "Project ID"
       },
       "dataset_id": {
@@ -23,6 +23,25 @@
         "description": "The contents of your Service Account Key JSON file. See the <a href=\"https://docs.airbyte.com/integrations/sources/bigquery#setup-the-bigquery-source-in-airbyte\">docs</a> for more information on how to obtain this key.",
         "title": "Credentials JSON",
         "airbyte_secret": true
+      },
+     "additional_config": {
+        "type": "array",
+        "description": "If you do not want to copy the entire table, provide the table name and a filter condition.",
+        "title": "Table Filter Configuration",
+        "items": {
+          "type": "object",
+          "properties": {
+            "tablename": {
+              "type": "string",
+              "description": "The name of the table."
+            },
+            "filter_condition": {
+              "type": "string",
+              "description": "The filter condition to apply to the data."
+            }
+          },
+          "required": ["tablename", "filter_condition"]
+        }
       }
     }
   }


### PR DESCRIPTION
**Objetivo**:  
Permitir a aplicação de filtros em uma tabela, evitando a necessidade de copiar todos os dados.

**Implementação**:  
Foi criado um novo parâmetro, `additional_config`, que contém um array de objetos com dois campos: `tablename` e `filter_condition`. Esse parâmetro será fornecido na interface do Airbyte.

Durante a configuração do banco de dados, o `additional_config` é processado para gerar um mapa (`Map`) onde `tablename` é a chave e `filter_condition` o valor associado. Sempre que o método `queryTableFullRefresh` é executado, o sistema verifica se há um filtro correspondente ao `tablename` solicitado. Caso exista, o filtro especificado é aplicado automaticamente. 

